### PR TITLE
Added credentials.php, removed hacky goto exits

### DIFF
--- a/code/credentials.php
+++ b/code/credentials.php
@@ -1,0 +1,8 @@
+<?php
+$servername = 'localhost';
+$username   = 'root';
+$password   = '';
+$dbname     = 'jaseph';
+$usertable  = 'user';
+$posttable  = 'post';
+?>

--- a/code/index.php
+++ b/code/index.php
@@ -16,40 +16,37 @@
   </div>
   <div id="content">
     <?php
-
     /*
     This doesn't quite work yet. :thinking:
     */
-
     // Credentials for this server
-    $servername = 'localhost';
-    $username   = 'root';
-    $password   = '';
-    $dbname     = 'jaseph';
-    $usertable  = 'user';
-    $posttable  = 'post';
+    require('credentials.php');
+
+    $success = true;
 
     if(!$link = mysqli_connect($servername, $username, $password)) { // Connects to the mysql using above credentials
-      echo 'Could not connect to mysql server';
-      goto exit_;//return;
+      echo 'Could not connect to mysql server<br>';
+      $success = false;
     }
 
     if(!mysqli_select_db($link, $dbname)) { // Selects the $dbname database (in this case jaseph)
-      echo 'Could not select mysql database.';
-      goto exit_;//return;
+      echo 'Could not select mysql database.<br>';
+      $success = false;
     }
+    if($success) {
 
     $sql = "SELECT * FROM user, post";//$sql = "SELECT * FROM $posttable, $usertable";
 
-    echo $sql;
+    echo $sql . '<br>';
 
     if($result = mysqli_query($link, $sql)) { // Runs mysql query
-        echo "Successfully ran mysql query.";
+        echo "Successfully ran mysql query.<br>";
     } else {
-        echo "Error: " . $sql . "<br>" . mysqli_error($link);
+        echo "Error: $sql<br>" . mysqli_error($link) . '<br>';
     }
 
     print_r($result);
+    echo '<br>';
     echo '<table>';
     while($row = mysqli_fetch_array($result)) {
       echo '<tr>';
@@ -62,8 +59,8 @@
     echo '</table>';
 
     mysqli_close($link); // Closes mysql connection
-    exit_: ; // Workaround, if 'exit;' was used, it would ignore further actions, such as the following html block.
 
+    } else {echo 'failed<br>';}
     ?>
     <button id="swapper" onclick="swapStyle()">Hacker Mode</button>
   </div>

--- a/code/post.php
+++ b/code/post.php
@@ -14,29 +14,28 @@
   <div id="content">
     <?php
     // Credentials for this server
-    $servername = 'localhost';
-    $username   = 'root';
-    $password   = '';
-    $dbname     = 'jaseph';
-    $usertable  = 'user';
-    $posttable  = 'post';
+    require('credentials.php');
+
+    $success = true;
 
     print_r($_POST); // Debug, prints out contents of form
-
+    echo '<br>';
     if(!isset($_POST["title"]) || empty($_POST["title"]) || ctype_space($_POST["title"])) { //Check if the title is not set/empty/only spaces. Exit if true.
-      echo 'Title must not be empty!';
-      goto exit_;//return;
+      echo 'Title must not be empty!<br>';
+      $success = false;
     }
 
     if (!$link = mysqli_connect($servername, $username, $password)) { // Connects to the mysql using above credentials
-      echo 'Could not connect to mysql server';
-      goto exit_;//return;
+      echo 'Could not connect to mysql server.<br>';
+      $success = false;
     }
 
     if (!mysqli_select_db($link, $dbname)) { // Selects the $dbname database (in this case jaseph)
-      echo 'Could not select mysql database.';
-      goto exit_;//return;
+      echo 'Could not select mysql database.<br>';
+      $success = false;
     }
+
+    if($success) {
 
     $userid  = 1; // Temporary userid for sprint
     $title   = $_POST["title"];
@@ -45,13 +44,14 @@
     $sql = "INSERT INTO $posttable (userid, title, content) VALUES ('$userid', '$title', '$content')"; // Inserts data into the 'post' database
 
     if (mysqli_query($link, $sql)) { // Runs mysql query
-        echo "New record created successfully";
+        echo "New record created successfully<br>";
     } else {
-        echo "Error: " . $sql . "<br>" . mysqli_error($link);
+        echo "Error: $sql<br>" . mysqli_error($link) . '<br>';
     }
 
     mysqli_close($link); // Closes mysql connection
-    exit_: ; // Workaround, if 'exit;' was used, it would ignore further actions, such as the following html block.
+
+  } else {echo 'failed<br>';}
     ?>
     <br>
     <button id="swapper" onclick="swapStyle()">Hacker Mode</button>


### PR DESCRIPTION
Added 'credentials.php', which contains the login credentials of the mysql server and can be included in every file that needs these credentials using `require()`.

Changed hacky way (`goto exit`) of skipping the center code blocks if the mysql connection failed or if there is an invalid input into a boolean (`$success`) and an if-statement that checks if the code can continue.